### PR TITLE
Add self to db init callback

### DIFF
--- a/gsql/modules/mysqloo.lua
+++ b/gsql/modules/mysqloo.lua
@@ -44,11 +44,11 @@ function MODULE:init(dbhost, dbname, dbuser, dbpass, port, callback)
     -- Creating a new Database object
     self.connection = mysqloo.connect(dbhost, dbuser, dbpass, dbname, port)
     function self.connection:onConnected()
-        callback(true, 'success')
+        callback(true, 'success', self)
     end
     function self.connection:onConnectionFailed(err)
         file.Append('gsql_logs.txt', '[gsql][new] : ' .. err)
-        callback(false, 'err : ' .. err)
+        callback(false, 'err : ' .. err, nil)
     end
 
     if self.connection:status() ~= 0 and self.connection:status() ~= 1 then

--- a/gsql/modules/sqlite.lua
+++ b/gsql/modules/sqlite.lua
@@ -30,7 +30,7 @@ local helpers = include('../helpers.lua')
 
 --- Just does nothing, because the "sql" lib is loaded by default by Gmod
 function MODULE:init(dbhost, dbname, dbuser, dbpass, port, callback)
-    callback(true, 'success')
+    callback(true, 'success', self)
 end
 
 --- Start a new query with the sqlite lib

--- a/gsql/modules/tmysql.lua
+++ b/gsql/modules/tmysql.lua
@@ -46,12 +46,12 @@ function MODULE:init(dbhost, dbname, dbuser, dbpass, port, callback)
     self.connection, err = tmysql.initialize(dbhost, dbuser, dbpass, dbname, port or 3306, nil, CLIENT_MULTI_STATEMENTS)
     if err then
         file.Append('gsql_logs.txt', '[gsql][new] : ' .. err)
-        callback(false, 'err : ' .. err)
+        callback(false, 'err : ' .. err, nil)
         return
     end
     -- Gsql.cache[connUID] = self.connection
 
-    callback(true, 'success')
+    callback(true, 'success', self)
 end
 
 --- Starts a new query with the existing connection


### PR DESCRIPTION
Allows devs to set the database object on success. Used to fix an issue where `sqlite` modules would execute the callback before returning the new gSql module. Better than using `timer.Simple(0, func)`